### PR TITLE
fix: remove use of deprecated Skill.OVERALL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.30'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/preeocxp/ConfigSkill.java
+++ b/src/main/java/com/preeocxp/ConfigSkill.java
@@ -1,0 +1,45 @@
+package com.preeocxp;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.Skill;
+
+@RequiredArgsConstructor
+public enum ConfigSkill
+{
+	ATTACK("Attack"),
+	DEFENCE("Defence"),
+	STRENGTH("Strength"),
+	HITPOINTS("Hitpoints"),
+	RANGED("Ranged"),
+	PRAYER("Prayer"),
+	MAGIC("Magic"),
+	COOKING("Cooking"),
+	WOODCUTTING("Woodcutting"),
+	FLETCHING("Fletching"),
+	FISHING("Fishing"),
+	FIREMAKING("Firemaking"),
+	CRAFTING("Crafting"),
+	SMITHING("Smithing"),
+	MINING("Mining"),
+	HERBLORE("Herblore"),
+	AGILITY("Agility"),
+	THIEVING("Thieving"),
+	SLAYER("Slayer"),
+	FARMING("Farming"),
+	RUNECRAFT("Runecraft"),
+	HUNTER("Hunter"),
+	CONSTRUCTION("Construction"),
+	OVERALL("Overall");
+
+	@Getter
+	private final String name;
+
+	public Skill toSkill() {
+		if (this == OVERALL)
+			return null;
+
+
+		return Skill.valueOf(this.name.toUpperCase());
+	}
+}

--- a/src/main/java/com/preeocxp/PreEocXpConfig.java
+++ b/src/main/java/com/preeocxp/PreEocXpConfig.java
@@ -1,6 +1,5 @@
 package com.preeocxp;
 
-import net.runelite.api.Skill;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -27,9 +26,9 @@ public interface PreEocXpConfig extends Config
 			description = "Choose which Skill to display",
 			position = 1
 	)
-	default Skill displaySkill()
+	default ConfigSkill displaySkill()
 	{
-		return Skill.OVERALL;
+		return ConfigSkill.OVERALL;
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/preeocxp/PreEocXpOverlay.java
+++ b/src/main/java/com/preeocxp/PreEocXpOverlay.java
@@ -2,7 +2,6 @@ package com.preeocxp;
 
 import net.runelite.api.Client;
 import net.runelite.api.Point;
-import net.runelite.api.Skill;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
@@ -12,7 +11,6 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
-import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.ImageUtil;
 
 import javax.inject.Inject;
@@ -43,7 +41,7 @@ public class PreEocXpOverlay extends Overlay
 
 	private final Tooltip xpTooltip = new Tooltip(new PanelComponent());
 
-	private Skill skillChosen =  Skill.OVERALL;
+	private ConfigSkill skillChosen =  ConfigSkill.OVERALL;
 	private static int lotsThreshold = 100000000; //100 million
 	private static int shrinkValue = 0;
 	private static final LinkedList<Integer> xpStored = new LinkedList<Integer> ();

--- a/src/main/java/com/preeocxp/PreEocXpPlugin.java
+++ b/src/main/java/com/preeocxp/PreEocXpPlugin.java
@@ -27,7 +27,6 @@ package com.preeocxp;
 import com.google.inject.Provides;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
-import net.runelite.api.Skill;
 import net.runelite.api.events.*;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -119,7 +118,7 @@ public class PreEocXpPlugin extends Plugin
 
 		tickCounter ++;
 		long overallXp = client.getOverallExperience();
-		if (config.displaySkill() == Skill.OVERALL) {
+		if (config.displaySkill() == ConfigSkill.OVERALL) {
 			skillXp = overallXp;
 		}
 		preXp = loginXp;
@@ -179,8 +178,8 @@ public class PreEocXpPlugin extends Plugin
 	@Subscribe
 	public void onStatChanged(StatChanged statChanged)
 	{
-		if (config.displaySkill() != Skill.OVERALL) {
-			skillXp = client.getSkillExperience(config.displaySkill());
+		if (config.displaySkill() != ConfigSkill.OVERALL) {
+			skillXp = client.getSkillExperience(config.displaySkill().toSkill());
 	}
 	}
 	/**
@@ -192,8 +191,8 @@ public class PreEocXpPlugin extends Plugin
     public void onConfigChanged(ConfigChanged configChanged)
     {
 	    setConfigUpdateState(true);
-		if (config.displaySkill() != Skill.OVERALL) {
-			skillXp = client.getSkillExperience(config.displaySkill());
+		if (config.displaySkill() != ConfigSkill.OVERALL) {
+			skillXp = client.getSkillExperience(config.displaySkill().toSkill());
 		}
     }
 


### PR DESCRIPTION
fix: remove the usage of Skill.OVERALL by replicating the deprecated enum and converting when required.

I tried to make it as drop-in friendly as possible so that people with pre-existing configs don't notice any issues. 

fixes #3 #5 #6 